### PR TITLE
印刷時に表示される空のサイドバーを表示しないように変更

### DIFF
--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -722,3 +722,9 @@ table.revision-info a {
 table.revision-info a:hover {
   color:#D14848;
 }
+
+@media print {
+  #content {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
このテーマは見やすくていつも使わせていただいています。

印刷時に空のサイドバーが表示される問題がありました。デフォルトのテーマから察するにサイドバーは表示されるべきではないと思いましたので、簡単ですがPRをさせていただきます。

ご確認の上マージいただけますと幸いです。

![image](https://user-images.githubusercontent.com/12361395/38741412-da026cfa-3f74-11e8-8e97-26d073ffb2a6.png)