### PR TITLE
guide.redmine.jpをredmine.jp/guideに変更

### DIFF
--- a/javascripts/theme.js
+++ b/javascripts/theme.js
@@ -13,7 +13,7 @@ $(function(){
 
   if (($("a.help").text() == "ヘルプ" ? "ja" : $("html").attr("lang")) == "ja") {
     /* When the language is Japanese, the link destination of help is Redmine.jp */
-    $("a.help").attr("href", "http://guide.redmine.jp/");
+    $("a.help").attr("href", "https://redmine.jp/guide/");
 
     /* Show scope in search in search box placeholder */
     $("body").attr("class").match(/controller-[\S]+/);


### PR DESCRIPTION
Redmineガイドの日本語訳サイトを http://guide.redmine.jp/ から https://redmine.jp/guide/ に移設しました。
テーマの中のリンク先を変更していただければと思います。