### PR TITLE
Redmine6に合わせてfont-sizeの設定を最新化

### DIFF
--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -17,7 +17,6 @@
 
 body {
   font-family: Meiryo, "Hiragino Kaku Gothic Pro", "MS PGothic", Verdana, sans-serif;
-  font-size: 13px;
   color: #222;
 }
 
@@ -35,7 +34,6 @@ h1, h2, h3, h4 {
 }
 
 #header h1 {
-  font-size: 22px;
   text-shadow: -1px -1px 1px rgba(0, 0, 0, 0.3);
 }
 
@@ -51,7 +49,6 @@ h1, h2, h3, h4 {
   padding: 5px 8px 4px 8px;
   background-position: 6px 50%;
   background-repeat: no-repeat;
-  font-size: 11px;
   font-weight: normal;
   border-radius: 3px 3px 0px 0px;
 }
@@ -150,20 +147,8 @@ a#toggle-completed-versions {
 
 /***** Tables *****/
 
-table.list {
-  font-size: 12px;
-}
-
 table.list th {
   padding: 4px 2px
-}
-
-table.attributes {
-  font-size: 12px;
-}
-
-table.attributes td {
-  padding: 1px;
 }
 
 tr.changeset td.author {
@@ -184,11 +169,6 @@ tr.version.closed, tr.version.closed a {
 
 table.list.issues tr.closed td {
   opacity: 0.7;
-}
-
-tr.assigned-to-me td.assigned_to, tr.created-by-me td.author {
-  font-weight: bold;
-  font-size: 11px;
 }
 
 td.parent {
@@ -321,10 +301,6 @@ tr.priority-lowest a {
   word-wrap: break-word;
 }
 
-.contextual {
-  font-size: 12px
-}
-
 .issue .contextual {
   margin: 0;
   padding: 2px 3px;
@@ -333,18 +309,10 @@ tr.priority-lowest a {
   border: 1px solid #e6e6cf;
 }
 
-/* submitボタンを押しやすく */
-input[type="submit"], input[type="reset"] {
-  -webkit-appearance: button;
-  cursor: pointer;
-  font-size: 12px;
-}
-
 /* テキストボックスで等幅フォントを使用 */
 
 input[type="text"] {
   font-family: "Osaka-Mono", "MS Gothic", sans-serif;
-  font-size: 100%;
 }
 
 textarea.wiki-edit {
@@ -384,10 +352,6 @@ div#relations .contextual a {
     padding-top: 2px;
 }
 
-.buttons {
-  font-size: 12px
-}
-
 div#activity dt .time {
   color: #484848
 }
@@ -409,10 +373,6 @@ form .attributes p {
   padding-bottom: 2px;
 }
 
-form#issue-form small {
-  font-size: 11px;
-}
-
 div.wiki-page .contextual a {
   opacity: 0.7
 }
@@ -422,7 +382,6 @@ ul.projects div.root a.project {
 }
 
 p.other-formats {
-  font-size: 12px;
   color: #484848;
 }
 
@@ -621,10 +580,6 @@ a[href*="activity"][data-absolute-date*=":"]:before {
   width: 77%;
 }
 
-.author {
-  font-size: 12px;
-}
-
 div.projects.box > ul > li > a {
   font-weight: bold;
 }
@@ -635,7 +590,6 @@ div.journal {
 }
 
 div.journal ul.details {
-  font-size: 12px;
   color: #444;
   background: #f6f6f6;
   border-radius: 3px;
@@ -654,9 +608,7 @@ div.journal ul.details i:after {
   font-style: normal;
 }
 
-div.journal h4:first-child {
-  font-size: 12px;
-  font-weight: normal;
+div.journal h4.note-header {
   color: #444;
 }
 

--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -49,6 +49,7 @@ h1, h2, h3, h4 {
   padding: 5px 8px 4px 8px;
   background-position: 6px 50%;
   background-repeat: no-repeat;
+  font-size: 0.750rem;
   font-weight: normal;
   border-radius: 3px 3px 0px 0px;
 }

--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -316,7 +316,7 @@ input[type="text"] {
 }
 
 textarea.wiki-edit {
-  font-size: 14px;
+  font-size: 0.875rem;
   font-family: "Osaka-Mono", "MS Gothic", sans-serif;
   letter-spacing: normal;
   line-height: 130%;
@@ -508,7 +508,7 @@ a.png {
 }
 
 #login-form input#username, #login-form input#password {
-    font-size: 15px;
+    font-size: 0.9375rem;
     padding: 3px;
 }
 


### PR DESCRIPTION
このプルリクエストではフォントサイズをRedmine6のDefaultテーマを踏まえて変更しています。
  
#### 変更内容:

- フォントサイズが Default テーマより小さいか同じの場合 → フォントサイズの上書きを削除  
- フォントサイズが Default テーマより大きい場合 → 上書きは維持しつつ、フォントサイズの単位を `px` から `rem` に変更  

また、フォントサイズの変更を行う過程で Redmine 本体に同等のスタイルが適用されているなど、上書きが不要と判断できるスタイルをいくつか削除しました。  

変更内容の大半はfarend_basicの https://github.com/farend/redmine_theme_farend_basic/pull/7 と同じで、違う点は以下の二点
- farend_fancyではサイドバーの幅を変更していなかったため、farend_basicのようにサイドバー関連のスタイル定義の削除を行っていない
- ~farend_fancyではメインメニューに独自のアイコンを表示している関係で#main-menuに対する定義に違いがあり、元のfont-sizeも違う。font-sizeの上書きをやめてもレイアウトが崩れないことは確認済み~ ~https://github.com/farend/redmine_theme_farend_fancy/compare/cleanup-fontsize?expand=1#diff-3832716ec9780c95af93fd2aa923aca41d508379718d6e08b898619e17ae684fL50-L57~
  - メインメニューは独自のアイコンを表示している関係で、一覧性を損なわないようにデフォルトテーマより小さい文字サイズにすることに
  - デフォルト: 13.02px(0.875remの93%), fancy: 12px(0.750rem)