### PR TITLE
テキストエリアのフォント設定がproportionalでない場合のフォントを上書きするように変更

### DIFF
--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -310,17 +310,13 @@ tr.priority-lowest a {
   border: 1px solid #e6e6cf;
 }
 
-/* テキストボックスで等幅フォントを使用 */
-
-input[type="text"] {
-  font-family: "Osaka-Mono", "MS Gothic", sans-serif;
+/* proportional でない場合にフォントを変更 */
+body:not(.textarea-proportional) input[type="text"], body:not(.textarea-proportional) textarea.wiki-edit {
+  font-family: "Osaka-Mono", "MS Gothic", monospace;
 }
 
 textarea.wiki-edit {
   font-size: 0.875rem;
-  font-family: "Osaka-Mono", "MS Gothic", sans-serif;
-  letter-spacing: normal;
-  line-height: 130%;
 }
 
 div.issue {


### PR DESCRIPTION
`input[type="text"]` と `textarea.wiki-edit` のフォント設定を、テキストエリアのフォント設定がproportionalかに応じて切り替えられるよう変更しました。
※ 今までもセレクターの優先順位によって実質的にテキストエリアのフォント設定がpropotionalの時にはテーマのフォントよりもデフォルトのフォントが優先されていましたが今後何か変更があっても上書きしてしまうことが無いように明確にした

加えて、等幅なのに sans-serifになっていた箇所をmonospaceに変更しました。

**farend_basicの https://github.com/farend/redmine_theme_farend_basic/pull/9 と同様の変更です。**

### 変更点:

- `textarea-proportional` クラスが **ない場合** → 等幅フォント (`Osaka-Mono`, `MS Gothic`, `monospace`) を適用
- `textarea-proportional` クラスが **ある場合** → デフォルトのフォント設定を維持
- `textarea.wiki-edit` の `letter-spacing` と `line-height` の指定を削除（デフォルトと同じだったため）

| テーマ | 要素 | テキストエリアのフォント設定(デフォルト) | テキストエリアのフォント設定(等幅) | テキストエリアのフォント設定(プロポーショナル) |
|--------|------|-----------|------|-----------------|
| **default (master)** | **input** | Arial(UserAgentSheet) | Arial(UserAgentSheet) | Arial(UserAgentSheet) |
|  | **textarea** | monospace(UserAgentSheet) | Consolas, Menlo, "Liberation Mono", Courier, monospace | "Noto Sans", sans-serif |
| **farend_fancy (master)** | **input** | Osaka-Mono, "MS Gothic", monospace | Osaka-Mono, "MS Gothic", monospace | デフォルトテーマと同じ |
|  | **textarea** | Osaka-Mono, "MS Gothic", monospace | Osaka-Mono, "MS Gothic", monospace | デフォルトテーマと同じ |

### 備考:

- textarea.wiki-edit のフォントサイズは 0.875rem に維持しています。これは、テキストエリアのフォント設定に関わらず適用します。