### PR TITLE
チケット一覧画面の.contextual span.drdnのメニューの見た目が崩れる問題を修正する

### DIFF
--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -602,15 +602,6 @@ body.controller-news.action-index .wiki {
   margin: 12px 0 20px 30px;
 }
 
-/* アイコン間のマージンを調整して識別しやすく */
-.contextual .icon, .buttons .icon {
-  margin-left: 5px;
-}
-
-.contextual .icon:first-child, .buttons .icon:first-child {
-  margin-left: 0;
-}
-
 /* リポジトリ画面でコミットメッセージを目立たせる */
 table.revision-info {
   color: #959595;

--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -509,27 +509,6 @@ a.png {
     padding: 3px;
 }
 
-/***** contextual menu *****/
-div.contextual a[href$="/issues"], a[href$="/time_entries"], a[href$="/activity"] {
-    background-position: 0 50%;
-    background-repeat: no-repeat;
-    padding-bottom: 3px;
-    padding-left: 20px;
-    padding-top: 2px;
-}
-
-div.contextual a[href$="/issues"] {
-    background-image: url("../images/ticket.png");
-}
-
-div.contextual a[href$="/time_entries"] {
-    background-image: url("../images/time.png");
-}
-
-div.contextual a[href$="/activity"] {
-    background-image: url("../images/activities.png");
-}
-
 div.attributes[id="attributes"] {
   border: 1px 0 0 0 0 solid #f00;
 }


### PR DESCRIPTION
チケット一覧画面の.contextual span.drdnのメニューを開くと、
* 設定に対してアイコンが二つ表示されている
* 左側の余白が違う

という問題があります。それらの問題を修正します。
<img width="374" alt="screenshot 2025-06-04 15 07 18" src="https://github.com/user-attachments/assets/64794ebc-b509-4d66-8ae5-50970a4a96a3" />


## 1. [チケット一覧画面にあるプロジェクト設定へのリンクにアイコンが二つ表示される問題を修正する](https://github.com/farend/redmine_theme_farend_fancy/commit/c1bb0f844ce7b699063d5408e03bc66c8ebb9185)

アイコンが二つ表示されている問題は [`div.contextual a[href$="/issues"]`](https://github.com/farend/redmine_theme_farend_fancy/compare/fix-contextual-menu-layout?expand=1#diff-3832716ec9780c95af93fd2aa923aca41d508379718d6e08b898619e17ae684fL521-L523) のセレクターに当てはまっていたためでした。
しかし、調べてみたところ現在のRedmineでは `div.contextual a[href$="/issues"]` , `div.contextual a[href$="/time_entries"]` , `div.contextual a[href$="/activity"]` に当てはまるリンクが見つからなかったため、現在は不要として関連するスタイルを削除しました。

## 2. [Defaultテーマ側で対応済みのため役割が重なるスタイルを削除](https://github.com/farend/redmine_theme_farend_fancy/commit/fe050e838eeae1a0cc00c8a54d86190858d48ead)

.contextual .icon:first-childの影響が.contextual span.drdnの内の.iconにも及んでいるため、左側の余白が違ってしまっています。
farend-fancyで実現しようとしていたスタイルは少し違う形でRedmine標準のスタイルとして導入済みなので、farend-fancy側でやる必要がなくなったということで役割が重なるスタイルを削除しました。
https://github.com/redmine/redmine/blob/200eced4692ba0ec3cd1df8e1d6b19ba06c419a3/app/assets/stylesheets/application.css#L2088