### PR TITLE
Redmine 6.0 向けのインストール手順を追記

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ https://github.com/farend/redmine_theme_farend_fancy/archive/master.zip
 
 アーカイブを展開した結果作成されたディレクトリをRedmineインストールディレクトリ以下のthemesディレクトリにfarend_fancyという名前でコピーしてください。
 
+#### Redmine6.0の場合
+
+Redmineのインストールディレクトリで以下のコマンドを実行してください。
+
+```
+git clone -b redmine6.0 https://github.com/farend/redmine_theme_farend_fancy.git themes/farend_fancy
+```
+
 #### Redmine5.1以前の場合
 
 Redmineのインストールディレクトリで以下のコマンドを実行してください。


### PR DESCRIPTION
今後 Redmine 6.1 の対応として、履歴画面のスタイル変更を行うと Redmine 6.0 との互換性がなくなるため、redmine6.0 タグを作成し、手順を説明しておく