### PR TITLE
Adjust for Redmine issue 43937

### DIFF
--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -16,112 +16,159 @@ body {
   font-family: Meiryo, "Hiragino Kaku Gothic Pro", "MS PGothic", Verdana, sans-serif;
 }
 
-#header {
-  background: #455b9d;
-  background: linear-gradient(#4f68b5, #455b9d, #455b9d); /* HSV(222, 50, 76) -> (222, 50, 68) -> (222, 50, 68) */
-}
-
 h1, h2, h3, h4 {
   font-family: Meiryo, "Hiragino Kaku Gothic Pro", "MS PGothic", Verdana, sans-serif
-}
-
-#header h1 {
-  text-shadow: -1px -1px 1px rgba(0, 0, 0, 0.3);
 }
 
 #content h1, h2, h3, h4 {
   color: var(--oc-gray-9, #212529); /* Initial value is fallbak for Redmine < 7.0 */
 }
 
-#main-menu li a, #main-menu li a:hover, #main-menu li a:active, #main-menu li a.selected, #main-menu li a.selected:hover {
-  padding: 5px 8px 4px 8px;
-  background-position: 6px 50%;
-  background-repeat: no-repeat;
+#header {
+  background: #455b9d;
+  background: linear-gradient(#4f68b5, #455b9d, #455b9d); /* HSV(222, 50, 76) -> (222, 50, 68) -> (222, 50, 68) */
+}
+
+#header h1 {
+  text-shadow: -1px -1px 1px rgba(0, 0, 0, 0.3);
+}
+
+/* Maintain original header/main-menu appearance after header redesign (redmine.org/issues/43937) */
+
+body #header, body.has-main-menu #header {
+  padding-block-end: 10px;
+  min-height: 8.7ex;
+}
+
+body #header h1 {
+  padding: 2px 10px 1px 0px;
+  min-block-size: 0;
+}
+
+#quick-search {
+  min-block-size: 0;
+  gap: 0;
+}
+
+#quick-search form {
+  margin-inline-end: 3px;
+}
+
+#quick-search form label {
+  margin-inline-end: 0px;
+}
+
+#main-menu {
+  background-color: transparent;
+  padding-block: 0;
+}
+
+#main-menu ul {
+  align-items: flex-end;
+  min-block-size: 0;
+}
+
+#main-menu li a {
   font-size: 0.750rem;
   font-weight: normal;
+  color: var(--oc-white, white);
+  line-height: initial;
+}
+
+#main-menu > ul > li > a,
+#main-menu > ul > li > a:hover,
+#main-menu > ul > li > a:active {
+  padding: 5px 8px 4px 8px;
+}
+
+#main-menu > ul > li > a,
+#main-menu > ul > li > a:hover,
+#main-menu > ul > li > a:active,
+#main-menu > ul > li > a.selected,
+#main-menu > ul > li > a.selected:hover {
+  background-position: 6px 50%;
+  background-repeat: no-repeat;
   border-radius: 3px 3px 0px 0px;
 }
 
-#main-menu li a.selected, #main-menu li a.selected:hover {
+#main-menu > ul > li > a.selected,
+#main-menu > ul > li > a.selected:hover {
   font-weight: bold;
   color: var(--oc-gray-9, #212529);
   box-shadow: 3px -2px 2px rgba(0, 0, 0, 0.1);
 }
 
-#main-menu li a.overview, #main-menu li a.overview:hover {
-  padding-left: 24px;
-  background-image: url(../images/information.png)
+#main-menu > ul > li > a:not(.selected):hover {
+  background-color: rgba(255, 255, 255, 0.2);
+  color: var(--oc-white, white);
 }
 
-#main-menu li a.activity, #main-menu li a.activity:hover {
+#main-menu > ul > li > a:is(.overview, .activity, .roadmap, .issues, .new-issue, .time-entries, .gantt, .calendar, .news, .documents, .wiki, .boards, .files, .repository, .settings) {
   padding-left: 24px;
-  background-image: url(../images/activities.png)
 }
 
-#main-menu li a.roadmap, #main-menu li a.roadmap:hover {
-  padding-left: 24px;
-  background-image: url(../images/package.png)
+#main-menu > ul > li > a.overview,
+#main-menu > ul > li > a.overview.selected,
+#main-menu > ul > li > a.overview.selected:hover { background-image: url(../images/information.png) }
+#main-menu > ul > li > a.activity,
+#main-menu > ul > li > a.activity.selected,
+#main-menu > ul > li > a.activity.selected:hover { background-image: url(../images/activities.png) }
+#main-menu > ul > li > a.roadmap,
+#main-menu > ul > li > a.roadmap.selected,
+#main-menu > ul > li > a.roadmap.selected:hover { background-image: url(../images/package.png) }
+#main-menu > ul > li > a.issues,
+#main-menu > ul > li > a.issues.selected,
+#main-menu > ul > li > a.issues.selected:hover { background-image: url(../images/ticket.png) }
+#main-menu > ul > li > a.new-issue,
+#main-menu > ul > li > a.new-issue.selected,
+#main-menu > ul > li > a.new-issue.selected:hover { background-image: url(../images/ticket_add.png) }
+#main-menu > ul > li > a.time-entries,
+#main-menu > ul > li > a.time-entries.selected,
+#main-menu > ul > li > a.time-entries.selected:hover { background-image: url(../images/time.png) }
+#main-menu > ul > li > a.gantt,
+#main-menu > ul > li > a.gantt.selected,
+#main-menu > ul > li > a.gantt.selected:hover { background-image: url(../images/gantt.png) }
+#main-menu > ul > li > a.calendar,
+#main-menu > ul > li > a.calendar.selected,
+#main-menu > ul > li > a.calendar.selected:hover { background-image: url(../images/calendar.png) }
+#main-menu > ul > li > a.news,
+#main-menu > ul > li > a.news.selected,
+#main-menu > ul > li > a.news.selected:hover { background-image: url(../images/news.png) }
+#main-menu > ul > li > a.documents,
+#main-menu > ul > li > a.documents.selected,
+#main-menu > ul > li > a.documents.selected:hover { background-image: url(../images/oxygen/document-multiple.png) }
+#main-menu > ul > li > a.wiki,
+#main-menu > ul > li > a.wiki.selected,
+#main-menu > ul > li > a.wiki.selected:hover { background-image: url(../images/page_edit.png) }
+#main-menu > ul > li > a.boards,
+#main-menu > ul > li > a.boards.selected,
+#main-menu > ul > li > a.boards.selected:hover { background-image: url(../images/comments.png) }
+#main-menu > ul > li > a.files,
+#main-menu > ul > li > a.files.selected,
+#main-menu > ul > li > a.files.selected:hover { background-image: url(../images/oxygen/package-x-generic.png) }
+#main-menu > ul > li > a.repository,
+#main-menu > ul > li > a.repository.selected,
+#main-menu > ul > li > a.repository.selected:hover { background-image: url(../images/database_gear.png) }
+#main-menu > ul > li > a.settings,
+#main-menu > ul > li > a.settings.selected,
+#main-menu > ul > li > a.settings.selected:hover { background-image: url(../images/project_settings.png) }
+
+#main-menu > ul > li > a.new-object {
+  padding: 5px 8px 4px 8px;
+  background: rgba(255, 255, 255, 0.2);
+  border-color: rgba(255, 255, 255, 0.4);
+  color: var(--oc-white, white);
 }
 
-#main-menu li a.issues, #main-menu li a.issues:hover {
-  padding-left: 24px;
-  background-image: url(../images/ticket.png)
+#main-menu > ul > li > a.new-object:hover {
+  background: rgba(255, 255, 255, 0.3);
 }
 
-#main-menu li a.new-issue, #main-menu li a.new-issue:hover {
-  padding-left: 24px;
-  background-image: url(../images/ticket_add.png)
-}
-
-
-#main-menu li a.time-entries, #main-menu li a.time-entries:hover {
-  padding-left: 24px;
-  background-image: url(../images/time.png)
-}
-
-#main-menu li a.gantt, #main-menu li a.gantt:hover {
-  padding-left: 24px;
-  background-image: url(../images/gantt.png)
-}
-
-#main-menu li a.calendar, #main-menu li a.calendar:hover {
-  padding-left: 24px;
-  background-image: url(../images/calendar.png)
-}
-
-#main-menu li a.news, #main-menu li a.news:hover {
-  padding-left: 24px;
-  background-image: url(../images/news.png)
-}
-
-#main-menu li a.documents, #main-menu li a.documents:hover {
-  padding-left: 24px;
-  background-image: url(../images/oxygen/document-multiple.png)
-}
-
-#main-menu li a.wiki, #main-menu li a.wiki:hover {
-  padding-left: 24px;
-  background-image: url(../images/page_edit.png)
-}
-
-#main-menu li a.boards, #main-menu li a.boards:hover {
-  padding-left: 24px;
-  background-image: url(../images/comments.png)
-}
-
-#main-menu li a.files, #main-menu li a.files:hover {
-  padding-left: 24px;
-  background-image: url(../images/oxygen/package-x-generic.png)
-}
-
-#main-menu li a.repository, #main-menu li a.repository:hover {
-  padding-left: 24px;
-  background-image: url(../images/database_gear.png)
-}
-
-#main-menu li a.settings, #main-menu li a.settings:hover {
-  padding-left: 24px;
-  background-image: url(../images/project_settings.png);
+#main-menu .tabs-buttons {
+  inset-inline-end: -3px;
+  inset-block-start: auto;
+  inset-block-end: 0;
+  transform: none;
 }
 
 /***** Links *****/


### PR DESCRIPTION
## Summary
[redmine.org/issues/43937](https://www.redmine.org/issues/43937) のヘッダー再設計後もfarend_fancyテーマで従来のヘッダー／メインメニュー表示を維持するための調整です。

## What Changed
- Redmine本体のCSSにセレクタの優先度で負けてアイコンが非表示になったりrepeatしていたため、全体的にセレクタの優先度を上げました。
- 再設計後のヘッダーレイアウトに合わせて `#main-menu` / `.tabs-buttons` / `#header` / `#quick-search` 周りを調整

## Screenshot

Redmine before issue #43937 + `farend_basic`
<img width="822" height="100" alt="screenshot 2026-04-21 15 27 28" src="https://github.com/user-attachments/assets/4cf18ff8-c666-4eae-8b51-fae0f027e088" />

Redmine after issue #43937 + `farend_basic` before changes
<img width="822" height="100" alt="screenshot 2026-04-21 15 28 16" src="https://github.com/user-attachments/assets/e2f972e5-8483-4b4b-a98d-ca0e2825b7eb" />

Redmine after issue #43937 + `farend_basic` after changes
<img width="822" height="100" alt="screenshot 2026-04-21 15 27 11" src="https://github.com/user-attachments/assets/f6f925b1-cb50-442e-8426-65ff5b689193" />