### PR TITLE
Fix pagination styles on issue page

### DIFF
--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -286,10 +286,7 @@ tr.priority-lowest a {
   word-wrap: break-word;
 }
 
-.issue .contextual {
-  margin: 0;
-  padding: 2px 3px;
-  border-radius: 3px;
+.issue .next-prev-links.contextual .pagination li {
   background: rgba(var(--oc-white-rgb, 255, 255, 255), 0.8);
   border: 1px solid var(--oc-gray-4, #ced4da);
 }

--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -286,11 +286,6 @@ tr.priority-lowest a {
   word-wrap: break-word;
 }
 
-.issue .next-prev-links.contextual .pagination li {
-  background: rgba(var(--oc-white-rgb, 255, 255, 255), 0.8);
-  border: 1px solid var(--oc-gray-4, #ced4da);
-}
-
 /* proportional でない場合にフォントを変更 */
 body:not(.textarea-proportional) input[type="text"], body:not(.textarea-proportional) textarea.wiki-edit {
   font-family: "Osaka-Mono", "MS Gothic", monospace;


### PR DESCRIPTION
## Summary

チケット表示画面のページネーションに二重でスタイルが適用されていたため修正します。
合わせて、チケット表示画面のページネーションをつけていましたが、デフォルトテーマに合わせて背景色を無くします。

## What Changed

チケット表示画面のページネーションに定義されているスタイルを削除する。

## Screenshots

before changes
<img width="206" height="68" alt="screenshot 2026-04-21 15 43 32" src="https://github.com/user-attachments/assets/ef1be10b-ad0a-402a-95c5-f0102e2de822" />

after changes (Redmine trunk)
<img width="175" height="36" alt="screenshot 2026-04-24 14 26 45" src="https://github.com/user-attachments/assets/8def5389-8472-44dd-864a-12a4f97689fe" />
after changes (Redmine 6.1-stable)
<img width="175" height="36" alt="screenshot 2026-04-24 14 30 00" src="https://github.com/user-attachments/assets/85893ee0-3d63-4fb0-911c-2003558255ca" />

