### PR TITLE
Adjust for Redmine issue 43937

### DIFF
--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -21,7 +21,7 @@ h1, h2, h3, h4 {
 }
 
 #content h1, h2, h3, h4 {
-  color: var(--oc-gray-9, #212529); /* Initial value is fallbak for Redmine < 7.0 */
+  color: var(--oc-gray-9, #212529); /* Initial value is fallback for Redmine < 7.0 */
 }
 
 #header {

--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -16,112 +16,118 @@ body {
   font-family: Meiryo, "Hiragino Kaku Gothic Pro", "MS PGothic", Verdana, sans-serif;
 }
 
-#header {
-  background: #455b9d;
-  background: linear-gradient(#4f68b5, #455b9d, #455b9d); /* HSV(222, 50, 76) -> (222, 50, 68) -> (222, 50, 68) */
-}
-
 h1, h2, h3, h4 {
   font-family: Meiryo, "Hiragino Kaku Gothic Pro", "MS PGothic", Verdana, sans-serif
-}
-
-#header h1 {
-  text-shadow: -1px -1px 1px rgba(0, 0, 0, 0.3);
 }
 
 #content h1, h2, h3, h4 {
   color: var(--oc-gray-9, #212529); /* Initial value is fallbak for Redmine < 7.0 */
 }
 
-#main-menu li a, #main-menu li a:hover, #main-menu li a:active, #main-menu li a.selected, #main-menu li a.selected:hover {
-  padding: 5px 8px 4px 8px;
-  background-position: 6px 50%;
-  background-repeat: no-repeat;
+#header {
+  background: #455b9d;
+  background: linear-gradient(#4f68b5, #455b9d, #455b9d); /* HSV(222, 50, 76) -> (222, 50, 68) -> (222, 50, 68) */
+}
+
+/* Maintain original header/main-menu appearance after header redesign (redmine.org/issues/43937) */
+
+body #header, body.has-main-menu #header {
+  padding-block-end: 10px;
+  min-height: 8.7ex;
+}
+
+body #header h1 {
+  padding: 2px 10px 1px 0px;
+  min-block-size: 0;
+  text-shadow: -1px -1px 1px rgba(0, 0, 0, 0.3);
+}
+
+#quick-search {
+  min-block-size: 0;
+  gap: 0;
+}
+
+#quick-search form {
+  margin-inline-end: 3px;
+}
+
+#quick-search form label {
+  margin-inline-end: 0px;
+}
+
+#main-menu {
+  background-color: transparent;
+  padding-block: 0;
+}
+
+#main-menu ul {
+  align-items: flex-end;
+  min-block-size: 0;
+}
+
+#main-menu li a {
   font-size: 0.750rem;
   font-weight: normal;
+  color: var(--oc-white, white);
+  line-height: initial;
+}
+
+#main-menu > ul > li > a {
+  --menu-pad-left: 8px; /* アイコン無しの場合は8px */
+  padding: 5px 8px 4px var(--menu-pad-left);
+  background-position: 6px 50%;
+  background-repeat: no-repeat;
   border-radius: 3px 3px 0px 0px;
 }
 
-#main-menu li a.selected, #main-menu li a.selected:hover {
+#main-menu li a.selected,
+#main-menu li a.selected:hover {
   font-weight: bold;
   color: var(--oc-gray-9, #212529);
-  box-shadow: 3px -2px 2px rgba(0, 0, 0, 0.1);
+  box-shadow: none;
 }
 
-#main-menu li a.overview, #main-menu li a.overview:hover {
-  padding-left: 24px;
-  background-image: url(../images/information.png)
+#main-menu > ul > li > a:not(.selected):hover {
+  background-color: rgba(255, 255, 255, 0.2);
+  color: var(--oc-white, white);
 }
 
-#main-menu li a.activity, #main-menu li a.activity:hover {
-  padding-left: 24px;
-  background-image: url(../images/activities.png)
+#main-menu a:is(.overview, .activity, .roadmap, .issues, .new-issue, .time-entries, .gantt, .calendar, .news, .documents, .wiki, .boards, .files, .repository, .settings) {
+  --menu-pad-left: 24px; /* アイコンありの場合は24px */
 }
 
-#main-menu li a.roadmap, #main-menu li a.roadmap:hover {
-  padding-left: 24px;
-  background-image: url(../images/package.png)
+#main-menu a.overview { background-image: url(../images/information.png) }
+#main-menu a.activity { background-image: url(../images/activities.png) }
+#main-menu a.roadmap { background-image: url(../images/package.png) }
+#main-menu a.issues { background-image: url(../images/ticket.png) }
+#main-menu a.new-issue { background-image: url(../images/ticket_add.png) }
+#main-menu a.time-entries { background-image: url(../images/time.png) }
+#main-menu a.gantt { background-image: url(../images/gantt.png) }
+#main-menu a.calendar { background-image: url(../images/calendar.png) }
+#main-menu a.news { background-image: url(../images/news.png) }
+#main-menu a.documents { background-image: url(../images/oxygen/document-multiple.png) }
+#main-menu a.wiki { background-image: url(../images/page_edit.png) }
+#main-menu a.boards { background-image: url(../images/comments.png) }
+#main-menu a.files { background-image: url(../images/oxygen/package-x-generic.png) }
+#main-menu a.repository { background-image: url(../images/database_gear.png) }
+#main-menu a.settings { background-image: url(../images/project_settings.png) }
+
+#main-menu > ul > li > a.new-object {
+  padding: 5px 8px 4px 8px;
+  background: rgba(255, 255, 255, 0.2);
+  border-color: rgba(255, 255, 255, 0.4);
+  color: var(--oc-white, white);
 }
 
-#main-menu li a.issues, #main-menu li a.issues:hover {
-  padding-left: 24px;
-  background-image: url(../images/ticket.png)
+#main-menu > ul > li > a.new-object:hover {
+  background: rgba(255, 255, 255, 0.3);
 }
 
-#main-menu li a.new-issue, #main-menu li a.new-issue:hover {
-  padding-left: 24px;
-  background-image: url(../images/ticket_add.png)
-}
-
-
-#main-menu li a.time-entries, #main-menu li a.time-entries:hover {
-  padding-left: 24px;
-  background-image: url(../images/time.png)
-}
-
-#main-menu li a.gantt, #main-menu li a.gantt:hover {
-  padding-left: 24px;
-  background-image: url(../images/gantt.png)
-}
-
-#main-menu li a.calendar, #main-menu li a.calendar:hover {
-  padding-left: 24px;
-  background-image: url(../images/calendar.png)
-}
-
-#main-menu li a.news, #main-menu li a.news:hover {
-  padding-left: 24px;
-  background-image: url(../images/news.png)
-}
-
-#main-menu li a.documents, #main-menu li a.documents:hover {
-  padding-left: 24px;
-  background-image: url(../images/oxygen/document-multiple.png)
-}
-
-#main-menu li a.wiki, #main-menu li a.wiki:hover {
-  padding-left: 24px;
-  background-image: url(../images/page_edit.png)
-}
-
-#main-menu li a.boards, #main-menu li a.boards:hover {
-  padding-left: 24px;
-  background-image: url(../images/comments.png)
-}
-
-#main-menu li a.files, #main-menu li a.files:hover {
-  padding-left: 24px;
-  background-image: url(../images/oxygen/package-x-generic.png)
-}
-
-#main-menu li a.repository, #main-menu li a.repository:hover {
-  padding-left: 24px;
-  background-image: url(../images/database_gear.png)
-}
-
-#main-menu li a.settings, #main-menu li a.settings:hover {
-  padding-left: 24px;
-  background-image: url(../images/project_settings.png);
+#main-menu .tabs-buttons {
+  inset-inline-end: -3px;
+  inset-block-start: auto;
+  inset-block-end: 0;
+  transform: none;
 }
 
 /***** Links *****/

--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -92,25 +92,27 @@ body #header h1 {
   color: var(--oc-white, white);
 }
 
-#main-menu a:is(.overview, .activity, .roadmap, .issues, .new-issue, .time-entries, .gantt, .calendar, .news, .documents, .wiki, .boards, .files, .repository, .settings) {
+#main-menu li a:is(.overview, .activity, .roadmap, .issues, .new-issue, .time-entries, .gantt, .calendar, .news, .documents, .wiki, .boards, .files, .repository, .settings) {
   --menu-pad-left: 24px; /* アイコンありの場合は24px */
+  background-repeat: no-repeat;
+  background-position: 6px 50%;
 }
 
-#main-menu a.overview { background-image: url(../images/information.png) }
-#main-menu a.activity { background-image: url(../images/activities.png) }
-#main-menu a.roadmap { background-image: url(../images/package.png) }
-#main-menu a.issues { background-image: url(../images/ticket.png) }
-#main-menu a.new-issue { background-image: url(../images/ticket_add.png) }
-#main-menu a.time-entries { background-image: url(../images/time.png) }
-#main-menu a.gantt { background-image: url(../images/gantt.png) }
-#main-menu a.calendar { background-image: url(../images/calendar.png) }
-#main-menu a.news { background-image: url(../images/news.png) }
-#main-menu a.documents { background-image: url(../images/oxygen/document-multiple.png) }
-#main-menu a.wiki { background-image: url(../images/page_edit.png) }
-#main-menu a.boards { background-image: url(../images/comments.png) }
-#main-menu a.files { background-image: url(../images/oxygen/package-x-generic.png) }
-#main-menu a.repository { background-image: url(../images/database_gear.png) }
-#main-menu a.settings { background-image: url(../images/project_settings.png) }
+#main-menu li a.overview { background-image: url(../images/information.png) }
+#main-menu li a.activity { background-image: url(../images/activities.png) }
+#main-menu li a.roadmap { background-image: url(../images/package.png) }
+#main-menu li a.issues { background-image: url(../images/ticket.png) }
+#main-menu li a.new-issue { background-image: url(../images/ticket_add.png) }
+#main-menu li a.time-entries { background-image: url(../images/time.png) }
+#main-menu li a.gantt { background-image: url(../images/gantt.png) }
+#main-menu li a.calendar { background-image: url(../images/calendar.png) }
+#main-menu li a.news { background-image: url(../images/news.png) }
+#main-menu li a.documents { background-image: url(../images/oxygen/document-multiple.png) }
+#main-menu li a.wiki { background-image: url(../images/page_edit.png) }
+#main-menu li a.boards { background-image: url(../images/comments.png) }
+#main-menu li a.files { background-image: url(../images/oxygen/package-x-generic.png) }
+#main-menu li a.repository { background-image: url(../images/database_gear.png) }
+#main-menu li a.settings { background-image: url(../images/project_settings.png) }
 
 #main-menu > ul > li > a.new-object {
   padding: 5px 8px 4px 8px;

--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -21,7 +21,7 @@ h1, h2, h3, h4 {
 }
 
 #content h1, #content h2, #content h3, #content h4 {
-  color: var(--oc-gray-9, #212529); /* Initial value is fallback for Redmine < 7.0 */
+  color: var(--oc-gray-9, #212529);
 }
 
 #header {
@@ -29,7 +29,7 @@ h1, h2, h3, h4 {
   background: linear-gradient(#4f68b5, #455b9d, #455b9d); /* HSV(222, 50, 76) -> (222, 50, 68) -> (222, 50, 68) */
 }
 
-/* Maintain original header/main-menu appearance after header redesign (redmine.org/issues/43937) */
+/* ヘッダー再設計後(redmine.org/issues/43937)も従来のヘッダー/メインメニュー表示を維持 */
 
 body #header, body.has-main-menu #header {
   padding-block-end: 10px;

--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -20,7 +20,7 @@ h1, h2, h3, h4 {
   font-family: Meiryo, "Hiragino Kaku Gothic Pro", "MS PGothic", Verdana, sans-serif
 }
 
-#content h1, h2, h3, h4 {
+#content h1, #content h2, #content h3, #content h4 {
   color: var(--oc-gray-9, #212529); /* Initial value is fallback for Redmine < 7.0 */
 }
 

--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -73,8 +73,7 @@ body #header h1 {
 }
 
 #main-menu > ul > li > a {
-  --menu-pad-left: 8px; /* アイコン無しの場合は8px */
-  padding: 5px 8px 4px var(--menu-pad-left);
+  padding: 5px 8px 4px 8px;
   background-position: 6px 50%;
   background-repeat: no-repeat;
   border-radius: 3px 3px 0px 0px;
@@ -93,7 +92,7 @@ body #header h1 {
 }
 
 #main-menu li a:is(.overview, .activity, .roadmap, .issues, .new-issue, .time-entries, .gantt, .calendar, .news, .documents, .wiki, .boards, .files, .repository, .settings) {
-  --menu-pad-left: 24px; /* アイコンありの場合は24px */
+  padding-left: 24px;
   background-repeat: no-repeat;
   background-position: 6px 50%;
 }

--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -91,27 +91,96 @@ body #header h1 {
   color: var(--oc-white, white);
 }
 
-#main-menu li a:is(.overview, .activity, .roadmap, .issues, .new-issue, .time-entries, .gantt, .calendar, .news, .documents, .wiki, .boards, .files, .repository, .settings) {
+#main-menu li a.overview, #main-menu li a.overview:hover {
   padding-left: 24px;
+  background-image: url(../images/information.png);
   background-repeat: no-repeat;
   background-position: 6px 50%;
 }
-
-#main-menu li a.overview { background-image: url(../images/information.png) }
-#main-menu li a.activity { background-image: url(../images/activities.png) }
-#main-menu li a.roadmap { background-image: url(../images/package.png) }
-#main-menu li a.issues { background-image: url(../images/ticket.png) }
-#main-menu li a.new-issue { background-image: url(../images/ticket_add.png) }
-#main-menu li a.time-entries { background-image: url(../images/time.png) }
-#main-menu li a.gantt { background-image: url(../images/gantt.png) }
-#main-menu li a.calendar { background-image: url(../images/calendar.png) }
-#main-menu li a.news { background-image: url(../images/news.png) }
-#main-menu li a.documents { background-image: url(../images/oxygen/document-multiple.png) }
-#main-menu li a.wiki { background-image: url(../images/page_edit.png) }
-#main-menu li a.boards { background-image: url(../images/comments.png) }
-#main-menu li a.files { background-image: url(../images/oxygen/package-x-generic.png) }
-#main-menu li a.repository { background-image: url(../images/database_gear.png) }
-#main-menu li a.settings { background-image: url(../images/project_settings.png) }
+#main-menu li a.activity, #main-menu li a.activity:hover {
+  padding-left: 24px;
+  background-image: url(../images/activities.png);
+  background-repeat: no-repeat;
+  background-position: 6px 50%;
+}
+#main-menu li a.roadmap, #main-menu li a.roadmap:hover {
+  padding-left: 24px;
+  background-image: url(../images/package.png);
+  background-repeat: no-repeat;
+  background-position: 6px 50%;
+}
+#main-menu li a.issues, #main-menu li a.issues:hover {
+  padding-left: 24px;
+  background-image: url(../images/ticket.png);
+  background-repeat: no-repeat;
+  background-position: 6px 50%;
+}
+#main-menu li a.new-issue, #main-menu li a.new-issue:hover {
+  padding-left: 24px;
+  background-image: url(../images/ticket_add.png);
+  background-repeat: no-repeat;
+  background-position: 6px 50%;
+}
+#main-menu li a.time-entries, #main-menu li a.time-entries:hover {
+  padding-left: 24px;
+  background-image: url(../images/time.png);
+  background-repeat: no-repeat;
+  background-position: 6px 50%;
+}
+#main-menu li a.gantt, #main-menu li a.gantt:hover {
+  padding-left: 24px;
+  background-image: url(../images/gantt.png);
+  background-repeat: no-repeat;
+  background-position: 6px 50%;
+}
+#main-menu li a.calendar, #main-menu li a.calendar:hover {
+  padding-left: 24px;
+  background-image: url(../images/calendar.png);
+  background-repeat: no-repeat;
+  background-position: 6px 50%;
+}
+#main-menu li a.news, #main-menu li a.news:hover {
+  padding-left: 24px;
+  background-image: url(../images/news.png);
+  background-repeat: no-repeat;
+  background-position: 6px 50%;
+}
+#main-menu li a.documents, #main-menu li a.documents:hover {
+  padding-left: 24px;
+  background-image: url(../images/oxygen/document-multiple.png);
+  background-repeat: no-repeat;
+  background-position: 6px 50%;
+}
+#main-menu li a.wiki, #main-menu li a.wiki:hover {
+  padding-left: 24px;
+  background-image: url(../images/page_edit.png);
+  background-repeat: no-repeat;
+  background-position: 6px 50%;
+}
+#main-menu li a.boards, #main-menu li a.boards:hover {
+  padding-left: 24px;
+  background-image: url(../images/comments.png);
+  background-repeat: no-repeat;
+  background-position: 6px 50%;
+}
+#main-menu li a.files, #main-menu li a.files:hover {
+  padding-left: 24px;
+  background-image: url(../images/oxygen/package-x-generic.png);
+  background-repeat: no-repeat;
+  background-position: 6px 50%;
+}
+#main-menu li a.repository, #main-menu li a.repository:hover {
+  padding-left: 24px;
+  background-image: url(../images/database_gear.png);
+  background-repeat: no-repeat;
+  background-position: 6px 50%;
+}
+#main-menu li a.settings, #main-menu li a.settings:hover {
+  padding-left: 24px;
+  background-image: url(../images/project_settings.png);
+  background-repeat: no-repeat;
+  background-position: 6px 50%;
+}
 
 #main-menu > ul > li > a.new-object {
   padding: 5px 8px 4px 8px;


### PR DESCRIPTION
## Summary
[redmine.org/issues/43937](https://www.redmine.org/issues/43937) のヘッダー再設計後もfarend_fancyテーマで従来のヘッダー／メインメニュー表示を維持するための調整です。

## What Changed
- 従来のヘッダー／メインメニュー表示を維持するために、https://www.redmine.org/issues/43937で追加されたスタイル( `#main-menu` / `.tabs-buttons` / `#header` / `#quick-search` 周り)を上書き
- application.css内の記載順を関係性の強いスタイルが近くに書かれるように変更

## Screenshot

Redmine before issue #43937 + `farend_basic`
<img width="822" height="100" alt="screenshot 2026-04-21 15 27 28" src="https://github.com/user-attachments/assets/4cf18ff8-c666-4eae-8b51-fae0f027e088" />

Redmine after issue #43937 + `farend_basic` before changes
<img width="822" height="100" alt="screenshot 2026-04-21 15 28 16" src="https://github.com/user-attachments/assets/e2f972e5-8483-4b4b-a98d-ca0e2825b7eb" />

Redmine after issue #43937 + `farend_basic` after changes
<img width="811" height="94" alt="screenshot 2026-04-21 16 49 41" src="https://github.com/user-attachments/assets/a58e8eb8-825c-40ad-a42e-542da5baf599" />

## Note

複数コミットがありますが、マージ時にSquash mergeにして1つにまとめる予定です
https://github.com/farend/redmine_theme_farend_fancy/pull/22/commits/b549b06e2eaf9f7f2670a13eea471645ddabc6e3 のコミットによって6.1-stableとの互換性を保つことができます。